### PR TITLE
Add AngelChest compatibility, fixes #1

### DIFF
--- a/src/main/java/ru/xezard/items/remover/listeners/PlayerDeathListener.java
+++ b/src/main/java/ru/xezard/items/remover/listeners/PlayerDeathListener.java
@@ -19,6 +19,7 @@
 package ru.xezard.items.remover.listeners;
 
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemStack;
@@ -32,7 +33,7 @@ import java.util.stream.Collectors;
 public class PlayerDeathListener
 implements Listener
 {
-    @EventHandler
+    @EventHandler(priority= EventPriority.MONITOR)
     public void onDeath(PlayerDeathEvent event)
     {
         if (event.getKeepInventory() || event.getDrops().isEmpty())


### PR DESCRIPTION
changed EventPriority to avoid items collected by the AngelChest plugin being tagged with the [pdd] lore, fixes #1 